### PR TITLE
Autoset bet to 1 sol

### DIFF
--- a/src/components/BetTabs/Betslip.js
+++ b/src/components/BetTabs/Betslip.js
@@ -143,7 +143,7 @@ const Betslip = () => {
                                     disabled={!connected}
                                     max={10}
                                     min={0.1} 
-                                    defaultValue={0} 
+                                    defaultValue={1} 
                                     precision={4}
                                     placeholder="Bet Amount" 
                                     rounded="md" 


### PR DESCRIPTION
Resolves: #94
When placing A new bet, I would like the value of the bet to be preset to be 1 SOL.
Doing so will remove the message shown currently of "insufficient amount" when starting to make a bet