### PR TITLE
Change the confirmation message when placing a bet

### DIFF
--- a/src/components/BetTabs/Betslip.js
+++ b/src/components/BetTabs/Betslip.js
@@ -39,7 +39,7 @@ const Betslip = () => {
         logoImage,
         ROI,
     } = betSlip;
-    const { _id, pair, predictionPrice, expiryTime } = prediction;
+    const { _id, pair, predictionPrice, expiryTime, direction } = prediction;
 
     // show form errors when user tries to place bet with insufficient balance 
     // or with amount less than 0.1 SOL.
@@ -65,6 +65,10 @@ const Betslip = () => {
                 setBetslip={setBetslip}
                 betPlaced={betPlaced}
                 setBetPlaced={setBetPlaced}
+                firstCurrency={firstCurrency}
+                direction={direction}
+                predictionPrice={`${roundOff((predictionPrice / DIVISOR), 3)}  ${secondCurrency}`}
+                expiryTime={expiryTime}
                 {...props}
             />
         )

--- a/src/components/BetTabs/CreateBetButton.js
+++ b/src/components/BetTabs/CreateBetButton.js
@@ -13,6 +13,10 @@ export default function CreateBetButton(
         setBetslip,
         betPlaced,
         setBetPlaced,
+        firstCurrency,
+        direction,
+        expiryTime,
+        predictionPrice,
         ...props
     }
     ) {
@@ -162,7 +166,7 @@ export default function CreateBetButton(
                         </AlertDialogHeader>
             
                         <AlertDialogBody>
-                            Are you sure you want to make this bet?
+                            You are betting {amount} SOL that {firstCurrency} will settle { direction ? 'above' : 'below' } {predictionPrice} at {new Date(expiryTime).toLocaleString()}
                         </AlertDialogBody>
             
                         <AlertDialogFooter>
@@ -171,16 +175,13 @@ export default function CreateBetButton(
                             </Button>
                             <Button 
                                 color="gray.800"
-                                bg="blue.200"
-                                _hover={{
-                                    bg: "blue.100",
-                                }} 
+                                bg="green.200"
                                 onClick={createBet} 
                                 isLoading={isSaving}
                                 loadingText="Placing bet..."
                                 ml={3}
                             >
-                                Continue
+                                Confirm
                             </Button>
                         </AlertDialogFooter>
                     </AlertDialogContent>


### PR DESCRIPTION
Resolves: #96 
Result: 

<img width="500" alt="Screenshot 2022-08-29 at 22 51 58" src="https://user-images.githubusercontent.com/15368874/187288805-0a2bb023-69e1-4052-9cec-08172f7f9cf8.png">


The current confirmation message when placing a BET looks more like a warning than a confirmation.

AC:
- [x] Change the Title to "Confirm your Bet"
- [x] Change the body of the message to "You are betting XXX SOL that XCRYPTOX will settle above XXXX at XtimeX
- [x] Change the button to be "Confirm"

![image](https://user-images.githubusercontent.com/9040770/186843085-863d133e-90f6-4fb0-a37c-31408df6bcf3.png)
