### PR TITLE
Change the Chainlink Price feed banner 

### DIFF
--- a/src/components/Subheader/index.js
+++ b/src/components/Subheader/index.js
@@ -52,7 +52,7 @@ const ChainlinkFeedButton = () => {
                 bg: "whiteAlpha.300",
             }}
             onClick={() => {
-                window.open("https://docs.chain.link/docs/solana/data-feeds-solana/", "_blank");
+                window.open("https://data.chain.link", "_blank");
             }}
         >
             <Stack


### PR DESCRIPTION
Resolves: #98

AC:

 Change the link of the feed to be "https://data.chain.link/"