### PR TITLE
Reorder the bet to see the open bet first #100

### DIFF
--- a/api/predictions/index.js
+++ b/api/predictions/index.js
@@ -26,7 +26,10 @@ module.exports = async (req, res) => {
             }
         }
         
-        const predictions = await Prediction.find(query);
+        const predictions = await Prediction
+            .find(query)
+            .sort('-createdAt'); // Sort the bets by createdAt field descending
+        
         res.send(predictions);
     } catch (err) {
         console.error("Failed to get predictions, with error code: " + err.message);


### PR DESCRIPTION
Resolves: #100

The current UI shows the old bet first and it is not a very good UX.

AC:
- [x] Change the order of the bet, so that the first one to show are the one that can be placed