### PR TITLE
Change wording on Chainlink data feeds 

### DIFF
--- a/src/components/Subheader/index.js
+++ b/src/components/Subheader/index.js
@@ -65,7 +65,7 @@ const ChainlinkFeedButton = () => {
             >
             <HStack>
                 <Text color="gray.500" fontWeight={500}>
-                    Live prices from
+                    Live prices from Chainlink
                 </Text>
                 <Image
                     borderRadius='full'
@@ -74,7 +74,7 @@ const ChainlinkFeedButton = () => {
                     alt="Chainlink"
                 />
                 <Text color="gray.400" fontWeight={700}>
-                    Data Feed
+                    Data Feeds
                 </Text>
             </HStack>
             <ArrowUpIcon w="16px" h="16px" color="gray.500" transform="rotate(45deg)" />


### PR DESCRIPTION
Resolves: #114
- [x] Add the name "Chainlink" before the logo
- [x] Change the word "feed" to be plural "feeds"

<img width="305" alt="image" src="https://user-images.githubusercontent.com/9040770/188829803-ac3b4f77-389c-41e5-82fa-0fb0e40fc79e.png">
