### PR TITLE
Remove usdc-usd from the prediction as the price does not fluctuate enough 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ REACT_APP_BTC_USD=CzZQBrJCLqjXRfMjRN3fhbxur2QYHUzkpaRwkWsiPqbz
 REACT_APP_ETH_USD=2ypeVyYnZaW2TNYXXTaZq9YhYvnqcjCiifW1C6n8b7Go
 REACT_APP_LINK_USD=6N2eCQv8hBkyZjSzN1pe5QtznZL9bGn6TZzcFhaYSLTs
 REACT_APP_SOL_USD=HgTtcbcmp5BeThax5AU8vg4VwK79qAvAKKFMs8txMLW6
-REACT_APP_USDC_USD=4NmRgDfAZrfBHQBuzstMP5Bu1pgBzVn8u1djSvNrNkrN
 REACT_APP_USDT_USD=EkTcZ3StgQkahMtDBuREiaowjNUyeGnEDHnMbWgMGUJQ
 
 # This is the Chainlink program ID that you use to read price data from off-chain

--- a/api/predictions/schedulePredictions.js
+++ b/api/predictions/schedulePredictions.js
@@ -113,10 +113,6 @@ const pairs = [
         feedAddress: process.env.REACT_APP_LINK_USD
     },
     {
-        pair: 'USDC/USD',
-        feedAddress: process.env.REACT_APP_USDC_USD
-    },
-    {
         pair: 'USDT/USD',
         feedAddress: process.env.REACT_APP_USDT_USD
     }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -16,10 +16,6 @@ export const CURRENCY_PAIRS = [
         feedAddress: process.env.REACT_APP_LINK_USD
     },
     {
-        pair: 'USDC/USD',
-        feedAddress: process.env.REACT_APP_USDC_USD
-    },
-    {
         pair: 'USDT/USD',
         feedAddress: process.env.REACT_APP_USDT_USD
     }


### PR DESCRIPTION
Resolves: #119

The price of usdc-usd fluctuate so minimally that it would never hit the pre-set predictions

AC:
- [x] Remove it from Env example
- [x] Remove it from the code