### PR TITLE
chore: responsiveness completed

### DIFF
--- a/src/components/Subheader/index.js
+++ b/src/components/Subheader/index.js
@@ -70,7 +70,7 @@ const Subheader = () => {
         >
             <NextPredictionTimer />
             <Hide below="sm">
-            <ChainlinkFeedButton />
+                <ChainlinkFeedButton />
             </Hide>
         </HStack>
     );


### PR DESCRIPTION
On mobile make it wrap so that they are two rows, one is the text and the other is the "live prices from" sentence

![Screenshot 2022-09-19 at 10 42 49](https://user-images.githubusercontent.com/28502531/191043302-c19aba7d-cb63-464f-9dc4-b8d59d1dd3f4.jpg)


![Screenshot 2022-09-19 at 16 33 05](https://user-images.githubusercontent.com/28502531/191056354-7097df9b-45d1-4527-a1d6-f4607858cfea.jpg)
![Screenshot 2022-09-19 at 16 33 29](https://user-images.githubusercontent.com/28502531/191056358-763e91bc-dbca-4365-a524-3c6a730d7b2f.jpg)
![Screenshot 2022-09-19 at 16 33 47](https://user-images.githubusercontent.com/28502531/191056363-993ef85d-8511-4472-97a8-1afa72e18df6.jpg)
![Screenshot 2022-09-19 at 16 33 57](https://user-images.githubusercontent.com/28502531/191056368-e7d3d9b9-ff7e-42f2-89f9-08ee2e1dac46.jpg)
