### PR TITLE
[GITHUB-ACTION] Investigate and fix timeout issue.

### DIFF
--- a/.github/workflows/predictions-cron.yaml
+++ b/.github/workflows/predictions-cron.yaml
@@ -1,6 +1,5 @@
 name: schedule-predictions-bet-status-cron
 on:
-  pull_request:
   schedule:
     - cron: '0 * * * *'
 jobs:
@@ -16,4 +15,4 @@ jobs:
           command: |
             curl --request POST \
                   --url '${{ secrets.API_URL }}/predictions/schedulePredictions' \
-                  --header 'Authorization: Bearer ${{ secrets.API_SECRET_KEY }}'exit 1
+                  --header 'Authorization: Bearer ${{ secrets.API_SECRET_KEY }}'


### PR DESCRIPTION
Resolves:  #152

Currently the Github Action times out at times.

We should do the following, but timebox it and not go into a rabbit hole and find a quick solution if we see that avenues are stuck:

Try one of all of the following:
- Investigate what is taking too long and see if there is a time to short the time of this particular requests
- implement a retry feature if things fail. Retry should just be applied to the promise that fails and not ALL of them again
- Increase the timeout for the function to 2 minutes