### PR TITLE
add vercel.json overrides

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "yarn build",
+  "devCommand": "react-app-rewired start",
+  "installCommand": "yarn install",
+  "outputDirectory": "build"
+}


### PR DESCRIPTION
This project uses react-app-rewired to overwrite the default settings in create-react-app's webpack configuration. By default, Vercel utilizes the react-scripts start command which does not look for the overrides. This caused the webpack module resolution issues as identified in #174. This change adds the expected default build & development settings for Vercel that should be used for setup.

Resolves #174 